### PR TITLE
Get pve vnc connection details

### DIFF
--- a/VmConfig-test/angular.json
+++ b/VmConfig-test/angular.json
@@ -21,8 +21,11 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-builders/custom-webpack:browser",
           "options": {
+            "customWebpackConfig": {
+              "path": "webpack.custom.js"
+            },
             "outputPath": "dist/vm-config-test",
             "index": "src/index.html",
             "main": "src/main.ts",
@@ -70,7 +73,7 @@
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular-builders/custom-webpack:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "VmConfig-test:build:production"

--- a/VmConfig-test/src/app/show-vm/show-vm.component.html
+++ b/VmConfig-test/src/app/show-vm/show-vm.component.html
@@ -41,7 +41,7 @@
 
   <tr *ngIf="showConsole[vm.name]">
     <td colspan="7">
-      <div id="vnc-{{ vm.name }}" style="width: 100%; height: 500px; border: 1px solid #ccc;"></div>
+      <div [id]="'vnc-' + sanitizeId(vm.name)" style="width: 100%; height: 500px; border: 1px solid #ccc;"></div>
       <button class="btn btn-sm btn-warning mt-2" (click)="closeConsole(vm)">❌ Fermer la console</button>
     </td>
   </tr>

--- a/VmConfig-test/src/app/show-vm/show-vm.component.ts
+++ b/VmConfig-test/src/app/show-vm/show-vm.component.ts
@@ -1,8 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { ConsoleService } from '../services/console.service';
-
-declare var RFB: any; // Déclare RFB global chargé via le CDN
+import RFB from '@novnc/novnc/lib/rfb.js';
 
 @Component({
   selector: 'app-show-vm',
@@ -56,49 +55,58 @@ export class ShowVMComponent implements OnInit {
     this.showAddVmForm = false;
   }
 
+  sanitizeId(value: string): string {
+    return (value ?? '')
+      .toString()
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-');
+  }
+
   openConsole(vm: any, node: string = 'pve') {
-    const key = vm.name;
-    this.loadingConsole[key] = true;
+    const nameKey = vm.name;
+    const domId = this.sanitizeId(nameKey);
+    this.loadingConsole[nameKey] = true;
 
     this.consoleSvc.getWssUrlByName(node, vm.name).subscribe({
       next: ({ wssUrl }) => {
-        this.showConsole[key] = true;
-        setTimeout(() => this.connectNoVnc(key, wssUrl), 0);
+        this.showConsole[nameKey] = true;
+        setTimeout(() => this.connectNoVnc(nameKey, domId, wssUrl), 0);
       },
       error: (e) => {
         console.error('Erreur ouverture console', e);
-        this.loadingConsole[key] = false;
+        this.loadingConsole[nameKey] = false;
       }
     });
   }
 
-  private connectNoVnc(key: string, wssUrl: string) {
-  const container = document.getElementById(`vnc-${key}`) as HTMLDivElement | null;
-  if (!container) {
-    this.loadingConsole[key] = false;
-    return;
+  private connectNoVnc(nameKey: string, domId: string, wssUrl: string) {
+    const container = document.getElementById(`vnc-${domId}`) as HTMLDivElement | null;
+    if (!container) {
+      this.loadingConsole[nameKey] = false;
+      return;
+    }
+
+    try {
+      const rfb = new RFB(container, wssUrl, { repeaterID: '' });
+      rfb.viewOnly = false;
+      rfb.scaleViewport = this.scaleViewport;
+
+      rfb.addEventListener('connect', () => this.loadingConsole[nameKey] = false);
+      rfb.addEventListener('disconnect', (ev: any) => {
+        console.error('Console déconnectée', ev?.detail);
+        this.showConsole[nameKey] = false;
+        this.loadingConsole[nameKey] = false;
+        this.rfbByVm[nameKey] = undefined;
+      });
+
+      this.rfbByVm[nameKey] = rfb;
+    } catch (err) {
+      console.error('Erreur noVNC', err);
+      this.loadingConsole[nameKey] = false;
+      this.showConsole[nameKey] = false;
+    }
   }
-
-  try {
-    const rfb = new RFB(container, wssUrl, { repeaterID: '' });
-    rfb.viewOnly = false;
-    rfb.scaleViewport = this.scaleViewport;
-
-    rfb.addEventListener('connect', () => this.loadingConsole[key] = false);
-    rfb.addEventListener('disconnect', (ev: any) => {
-      console.error('Console déconnectée', ev?.detail);
-      this.showConsole[key] = false;
-      this.loadingConsole[key] = false;
-      this.rfbByVm[key] = undefined;
-    });
-
-    this.rfbByVm[key] = rfb;
-  } catch (err) {
-    console.error('Erreur noVNC', err);
-    this.loadingConsole[key] = false;
-    this.showConsole[key] = false;
-  }
-}
 
   toggleScale(vm: any) {
     this.scaleViewport = !this.scaleViewport;

--- a/VmConfig-test/src/app/show-vm/show-vm.component.ts
+++ b/VmConfig-test/src/app/show-vm/show-vm.component.ts
@@ -2,9 +2,6 @@ import { HttpClient } from '@angular/common/http';
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { ConsoleService } from '../services/console.service';
 
-// declare global RFB provided via CDN
-declare var RFB: any;
-
 @Component({
   selector: 'app-show-vm',
   standalone: false,
@@ -65,6 +62,40 @@ export class ShowVMComponent implements OnInit {
       .replace(/[^a-z0-9_-]+/g, '-');
   }
 
+  private ensureRfbAvailable(): Promise<any> {
+    const globalAny = window as any;
+    if (globalAny.RFB) return Promise.resolve(globalAny.RFB);
+
+    return new Promise((resolve, reject) => {
+      const existing = document.querySelector('script[data-novnc-loader="true"]') as HTMLScriptElement | null;
+      if (existing) {
+        const check = () => {
+          if ((window as any).RFB) resolve((window as any).RFB);
+          else setTimeout(check, 50);
+        };
+        check();
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.type = 'module';
+      script.dataset['novncLoader'] = 'true';
+      script.textContent = "import RFB from 'https://unpkg.com/@novnc/novnc/core/rfb.js'; window.RFB = RFB;";
+      script.onload = () => resolve((window as any).RFB);
+      script.onerror = (e) => reject(e);
+      document.head.appendChild(script);
+
+      const timeout = setTimeout(() => reject(new Error('Timeout chargement noVNC')), 10000);
+      const poll = () => {
+        if ((window as any).RFB) {
+          clearTimeout(timeout);
+          resolve((window as any).RFB);
+        } else setTimeout(poll, 50);
+      };
+      poll();
+    });
+  }
+
   openConsole(vm: any, node: string = 'pve') {
     const nameKey = vm.name;
     const domId = this.sanitizeId(nameKey);
@@ -82,7 +113,7 @@ export class ShowVMComponent implements OnInit {
     });
   }
 
-  private connectNoVnc(nameKey: string, domId: string, wssUrl: string) {
+  private async connectNoVnc(nameKey: string, domId: string, wssUrl: string) {
     const container = document.getElementById(`vnc-${domId}`) as HTMLDivElement | null;
     if (!container) {
       this.loadingConsole[nameKey] = false;
@@ -90,7 +121,8 @@ export class ShowVMComponent implements OnInit {
     }
 
     try {
-      const rfb = new RFB(container, wssUrl, { repeaterID: '' });
+      const RFBClass: any = await this.ensureRfbAvailable();
+      const rfb = new RFBClass(container, wssUrl, { repeaterID: '' });
       rfb.viewOnly = false;
       rfb.scaleViewport = this.scaleViewport;
 

--- a/VmConfig-test/src/app/show-vm/show-vm.component.ts
+++ b/VmConfig-test/src/app/show-vm/show-vm.component.ts
@@ -1,7 +1,9 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { ConsoleService } from '../services/console.service';
-import RFB from '@novnc/novnc/lib/rfb.js';
+
+// declare global RFB provided via CDN
+declare var RFB: any;
 
 @Component({
   selector: 'app-show-vm',

--- a/VmConfig-test/src/index.html
+++ b/VmConfig-test/src/index.html
@@ -10,12 +10,15 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <!-- Font Awesome -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+  <script type="module">
+    import RFB from 'https://unpkg.com/@novnc/novnc/core/rfb.js';
+    window.RFB = RFB;
+  </script>
 </head>
 <body>
   <app-root></app-root>
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="https://unpkg.com/@novnc/novnc/core/rfb.js"></script>
 
 </body>
 </html>

--- a/VmConfig-test/src/index.html
+++ b/VmConfig-test/src/index.html
@@ -15,6 +15,7 @@
   <app-root></app-root>
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://unpkg.com/@novnc/novnc/core/rfb.js"></script>
 
 </body>
 </html>

--- a/VmConfig-test/src/index.html
+++ b/VmConfig-test/src/index.html
@@ -10,10 +10,6 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <!-- Font Awesome -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-  <script type="module">
-    import RFB from 'https://unpkg.com/@novnc/novnc/core/rfb.js';
-    window.RFB = RFB;
-  </script>
 </head>
 <body>
   <app-root></app-root>

--- a/VmConfig-test/src/index.html
+++ b/VmConfig-test/src/index.html
@@ -15,7 +15,6 @@
   <app-root></app-root>
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://unpkg.com/@novnc/novnc/core/rfb.js"></script>
 
 </body>
 </html>

--- a/VmConfig-test/src/index.html
+++ b/VmConfig-test/src/index.html
@@ -10,6 +10,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <!-- Font Awesome -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/@novnc/novnc@1.4.0/core/rfb.js"></script>
 </head>
 <body>
   <app-root></app-root>

--- a/VmConfig-test/webpack.custom.js
+++ b/VmConfig-test/webpack.custom.js
@@ -1,0 +1,5 @@
+module.exports = (config) => {
+	config.experiments = config.experiments || {};
+	config.experiments.topLevelAwait = true;
+	return config;
+};


### PR DESCRIPTION
Revert noVNC import to CDN and sanitize VNC console DOM IDs.

The noVNC NPM package caused Angular build failures due to top-level await, necessitating a return to the CDN import. Additionally, a `sanitizeId` function was introduced to ensure valid HTML IDs for the VNC console container.

---
<a href="https://cursor.com/background-agent?bcId=bc-9826718e-ce99-45e8-a425-f9bc307f69a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9826718e-ce99-45e8-a425-f9bc307f69a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

